### PR TITLE
Remove trailing tag spaces, keep inline children inline, fix top-level sibling indent

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const stringify = (el, indentLevel = 0) => {
       const voidHtml = [`<${el.name}`, attrs, '/>'].filter(Boolean).join(' ')
       return indent(indentLevel, voidHtml)
     } else {
-      const allTextChildren = el.children.length === 1 && el.children[0].type === 'text'
+      const allTextChildren = !el.children.map(c => c.type).filter(t => t !== 'text').length
 
       const open = attrs ? `<${el.name} ${attrs}>` : `<${el.name}>`
       const close = `</${el.name}>`

--- a/index.js
+++ b/index.js
@@ -36,12 +36,18 @@ const stringify = (el, indentLevel = 0) => {
       const voidHtml = [`<${el.name}`, attrs, '/>'].filter(Boolean).join(' ')
       return indent(indentLevel, voidHtml)
     } else {
+      const allTextChildren = el.children.length === 1 && el.children[0].type === 'text'
+
       const open = attrs ? `<${el.name} ${attrs}>` : `<${el.name}>`
+      const close = `</${el.name}>`
+
+      if (allTextChildren) {
+        return indent(indentLevel, [open, el.children[0].data, close].join(''))
+      }
+
       const children = el.children.map(
         c => stringify(c, indentLevel + 1)
       ).filter(isPresent).join("\n")
-      const close = `</${el.name}>`
-
       return [
         indent(indentLevel, open),
         children,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = (html, options = {}) => {
     .children()
     .each((_, el) => elements.push(el))
 
-  return elements.map(stringify).join("\n")
+  return elements.map(el => stringify(el)).join("\n")
 }
 
 const stringify = (el, indentLevel = 0) => {

--- a/index.js
+++ b/index.js
@@ -53,13 +53,6 @@ const stringify = (el, indentLevel = 0) => {
   }
 }
 
-const indent = (level, str = '') => {
-  let indentStr = ''
-  for (let i = 0; i < level; i++) {
-    indentStr += INDENTATION_CHARS
-  }
-
-  return `${indentStr}${str}`
-}
+const indent = (level = 0, str = '') => `${Array(level + 1).join(INDENTATION_CHARS)}${str}`
 
 const stringifyAttrs = el => Object.keys(el.attribs).map(attr => `${attr}="${el.attribs[attr]}"`).join(' ')

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ const stringify = (el, indentLevel = 0) => {
       const close = `</${el.name}>`
 
       if (allTextChildren) {
-        return indent(indentLevel, [open, el.children[0].data, close].join(''))
+        const firstChild = el.children[0] || { data: '' }
+        return indent(indentLevel, [open, firstChild.data, close].join(''))
       }
 
       const children = el.children.map(

--- a/index.js
+++ b/index.js
@@ -31,12 +31,15 @@ module.exports = (html, options = {}) => {
 
 const stringify = (el, indentLevel = 0) => {
   if (el.children) {
+    const attrs = stringifyAttrs(el)
     if (isVoidElement(el.name)) {
-      return [`<${el.name}`, stringifyAttrs(el), '/>'].filter(Boolean).join(' ')
+      const voidHtml = [`<${el.name}`, attrs, '/>'].filter(Boolean).join(' ')
+      return indent(indentLevel, voidHtml)
     } else {
-      const attrs = stringifyAttrs(el)
-      const open = attrs ? `<${el.name} ${stringifyAttrs(el)}>` : `<${el.name}>`
-      const children = el.children.map(c => stringify(c, indentLevel + 1)).filter(isPresent).join("\n")
+      const open = attrs ? `<${el.name} ${attrs}>` : `<${el.name}>`
+      const children = el.children.map(
+        c => stringify(c, indentLevel + 1)
+      ).filter(isPresent).join("\n")
       const close = `</${el.name}>`
 
       return [

--- a/index.js
+++ b/index.js
@@ -32,9 +32,10 @@ module.exports = (html, options = {}) => {
 const stringify = (el, indentLevel = 0) => {
   if (el.children) {
     if (isVoidElement(el.name)) {
-      return indent(indentLevel, `<${el.name} ${stringifyAttrs(el)} />`)
+      return [`<${el.name}`, stringifyAttrs(el), '/>'].filter(Boolean).join(' ')
     } else {
-      const open = `<${el.name} ${stringifyAttrs(el)}>`
+      const attrs = stringifyAttrs(el)
+      const open = attrs ? `<${el.name} ${stringifyAttrs(el)}>` : `<${el.name}>`
       const children = el.children.map(c => stringify(c, indentLevel + 1)).filter(isPresent).join("\n")
       const close = `</${el.name}>`
 


### PR DESCRIPTION
Fixes 3 minor issues:
 - Opening `<tag >` with no attributes now correctly renders as `<tag>` (no extra space)
 - Inline children, such as `<a href="url">Link Text</a>` now renders inline, rather than as:
```
<a href="url">
  Link Text
</a>
```
This is important because the extra white-space actually changes what a browser will display.
 - HTML/XML fragments which have multiple top-level nodes no longer indent each child further, as:
```
<p>Fragment 1</p>
  <p>Fragment 2</p>
    <p>Fragment 3</p>
```