### PR TITLE
Blacklist pre and code but reformat all others

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,8 +42,11 @@ const stringify = (el, indentLevel = 0) => {
       const close = `</${el.name}>`
 
       if (allTextChildren) {
-        const firstChild = el.children[0] || { data: '' }
-        return indent(indentLevel, [open, firstChild.data, close].join(''))
+        let contents = el.children.map(c => c.data).join('')
+        if (!SKIP_CONTENT_FORMAT.includes(el.tagName)) {
+          contents = collapseWhitespace(contents)
+        }
+        return indent(indentLevel, [open, contents, close].join(''))
       }
 
       const children = el.children.map(
@@ -61,5 +64,8 @@ const stringify = (el, indentLevel = 0) => {
 }
 
 const indent = (level = 0, str = '') => `${Array(level + 1).join(INDENTATION_CHARS)}${str}`
+const collapseWhitespace = (content = '') => (
+  content.replace(/(\s)/g, ' ').replace(/(\s{2,})/g, ' ')
+)
 
 const stringifyAttrs = el => Object.keys(el.attribs).map(attr => `${attr}="${el.attribs[attr]}"`).join(' ')

--- a/test.js
+++ b/test.js
@@ -1,7 +1,49 @@
 import test from 'ava'
 import prettifyHtml from './'
 
-test('prettify-html makes the html pretty', t => {
+test('zero-out initial indentation', t => {
+  const INPUT = `        <div>Indented Text</div>`
+  const EXPECTED = '<div>Indented Text</div>'
+  t.is(prettifyHtml(INPUT), EXPECTED)
+})
+test('siblings at top-level are consistently indended', t => {
+  const INPUT = `
+    <div>First</div><div>Second</div>
+<div>Third</div>
+  `
+  const EXPECTED = [
+    '<div>First</div>',
+    '<div>Second</div>',
+    '<div>Third</div>',
+  ].join('\n')
+
+  t.is(prettifyHtml(INPUT), EXPECTED)
+})
+test('elements containing only text are trimmed/inlined', t => {
+  const INPUT = `
+    <div>   A bunch
+    of text
+
+    inside this element
+            </div>
+  `
+  const EXPECTED = `<div> A bunch of text inside this element </div>`
+  t.is(prettifyHtml(INPUT), EXPECTED)
+})
+
+
+test('innerHTML of code/pre blocks is not altered', t => {
+  const INPUT = `<code>
+    jQuery('selector').on('event', () => {
+      // Comment
+      window.alert('an alert');
+    })
+</code>`
+
+  t.is(prettifyHtml(INPUT), INPUT)
+})
+
+test.skip('prettify-html makes the html pretty', t => {
   const INPUT = `
 	<div class="dt-m dt-l ph2 pv4 pv5-l w-100 white bg-aqua-gradient">
     <div class="dn dtc-m dtc-l v-mid pa3 w-50">

--- a/test.js
+++ b/test.js
@@ -42,8 +42,15 @@ test('innerHTML of code/pre blocks is not altered', t => {
 
   t.is(prettifyHtml(INPUT), INPUT)
 })
+test('code/pre elements containing other XML tags are not altered', t => {
+  const INPUT = `<code>
+    <a href="link">Example code containing <b>tags</b></a>
+  </code>`
+  t.is(prettifyHtml(INPUT), INPUT)
+})
 
-test.skip('prettify-html makes the html pretty', t => {
+
+test('prettify-html makes the html pretty', t => {
   const INPUT = `
 	<div class="dt-m dt-l ph2 pv4 pv5-l w-100 white bg-aqua-gradient">
     <div class="dn dtc-m dtc-l v-mid pa3 w-50">
@@ -70,26 +77,21 @@ test.skip('prettify-html makes the html pretty', t => {
   `
 
   const EXPECTED = `<div class="dt-m dt-l ph2 pv4 pv5-l w-100 white bg-aqua-gradient">
-	<div class="dn dtc-m dtc-l v-mid pa3 w-50">
-		<div class="pa3 ph4-m ph5-l">
-			<img src="/assets/site/v2/letter.png" class="w-100" />
-		</div>
-	</div>
-	<div class="dtc-m dtc-l v-mid w-100 w-50-m w-50-l ph4 pb4">
-		<h1 class="fw6 mt0">
-			Enrichment
-		</h1>
-		<div class="pb3 pb4-m pb4-l">
-			<h2 class="fw3 lh-copy f5 w-100 w-80-m w-60-l pv3">
-				Turn any email or domain into a full person or company profile to qualify leads.
-			</h2>
-		</div>
-		<div class="cf">
-			<a class="ph5 bg-white ph3 pv3-5 no-underline grow br2 fw6 f6 ttu tracked tc big-dark-box-shadow blue" href="#" title="Sign Up">Sign Up</a>
-		</div>
-	</div>
-</div>
-`
+  <div class="dn dtc-m dtc-l v-mid pa3 w-50">
+    <div class="pa3 ph4-m ph5-l">
+      <img src="/assets/site/v2/letter.png" class="w-100" />
+    </div>
+  </div>
+  <div class="dtc-m dtc-l v-mid w-100 w-50-m w-50-l ph4 pb4">
+    <h1 class="fw6 mt0">Enrichment</h1>
+    <div class="pb3 pb4-m pb4-l">
+      <h2 class="fw3 lh-copy f5 w-100 w-80-m w-60-l pv3"> Turn any email or domain into a full person or company profile to qualify leads. </h2>
+    </div>
+    <div class="cf">
+      <a class="ph5 bg-white ph3 pv3-5 no-underline grow br2 fw6 f6 ttu tracked tc big-dark-box-shadow blue" href="#" title="Sign Up">Sign Up</a>
+    </div>
+  </div>
+</div>`
 
 	const results = prettifyHtml(INPUT)
 


### PR DESCRIPTION
This PR addresses #1, splitting the processing of non-Void tags into 2 paths:
 1. `<pre>` and `<code>` (or any other tag included in the `SKIP_CONTENT_FORMAT` array) are re-parsed separately, and simply re-included as unaltered HTML
 2. all other non-Void tags are parsed as before